### PR TITLE
Fix loop parameters in Youtube player

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -18,7 +18,7 @@
     "@vtex/tsconfig": "^0.4.4",
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "version": "1.0.0"
 }

--- a/react/players/YoutubePlayer.tsx
+++ b/react/players/YoutubePlayer.tsx
@@ -18,12 +18,11 @@ const YoutubePlayer: FunctionComponent<VideoPlayer> = ({
   description,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const params = `autoplay=${autoPlay}&loop=${loop}&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&controls=${
-    controlsType === 'none' ? 0 : 1
-  }`
-
   const matchedSrc = src.match(YOUTUBE_REGEX)
   const videoId = matchedSrc?.[1]
+  const params = `autoplay=${autoPlay}&loop=${loop ? '1&playlist=' + videoId : '0'}&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&controls=${
+    controlsType === 'none' ? 0 : 1
+  }`
 
   return (
     <div className={`relative ${handles.videoContainer}`}>

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4813,12 +4813,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.9.7:
+typescript@3.9.7, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
According to Youtube's [reference](https://developers.google.com/youtube/player_parameters?hl=pt-br#Selecting_Content_to_Play), it may happen to be necessary to define the _playlist_ parameter as well in order to have the loop feature working properly. Also, the correct set of values for _loop_ is ["0", "1"].

Tested in:
https://beta.dunloppneus.com.br/?workspace=ytfix