### PR TITLE
[Trivial] Exporting CSS Handles embedded within Video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Exports CSS Handles embedded within `Video` component.
 
 ## [1.2.0] - 2021-01-15
 ### Fixed

--- a/react/Video.tsx
+++ b/react/Video.tsx
@@ -3,7 +3,7 @@ import { jsonLdScriptProps } from 'react-schemaorg'
 
 import type { VideoPlayer } from './VideoTypes'
 import VimeoPlayer from './players/VimeoPlayer'
-import HTML5Player from './players/HTML5Player'
+import HTML5Player, { CSS_HANDLES } from './players/HTML5Player'
 import YoutubePlayer from './players/YoutubePlayer'
 
 const VIMEO_PATTERN = /vimeo/
@@ -51,5 +51,7 @@ function Video(props: VideoPlayer) {
 Video.schema = {
   title: 'admin/editor.video.title',
 }
+
+Video.cssHandles = CSS_HANDLES
 
 export default Video


### PR DESCRIPTION
#### What problem is this solving?

This PR changes the way CSS Handles are exported by the Video component. By exporting this new way, other components can import and use these handles.

#### How to test it?

[Workspace](https://icaromedia5--storecomponents.myvtex.com/)

#### Screenshots or example usage:

<img width="384" alt="Screen Shot 2021-01-28 at 16 10 26" src="https://user-images.githubusercontent.com/8127610/106186661-5800f580-6183-11eb-865b-15bb3f699a17.png">

#### Related to / Depends on

Related to [store-media#2](https://github.com/vtex-apps/store-video/pull/2)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Y1Y0hB0FHx1vsfa6O3/giphy-downsized.gif)
