### PR TITLE
Automatically setting playsInline to true when autoPlay is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `playsInline` not being automatically enabled when autoPlay is enabled
 
 ## [1.4.0] - 2021-03-08
 ### Added

--- a/react/players/HTML5Player.tsx
+++ b/react/players/HTML5Player.tsx
@@ -114,7 +114,7 @@ function HTML5Player({
           autoPlay={autoPlay}
           controls={hasNativeControls}
           muted={autoPlay ? true : muted}
-          playsInline={playsInline}
+          playsInline={autoPlay ? true : playsInline}
         >
           <source src={src} type={type && `video/${type}`} />
 


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes the behavior of playsInline when autoplay is enabled: it should always be true, as mentioned in the [previous PR](https://github.com/vtex-apps/store-video/pull/7#issue-585846445).

#### How to test it?

[Workspace](https://icarovtexvideo--muji.myvtex.com/how-to-muji-face-soap?__bindingAddress=www.mujionline.eu/uk)

#### Related to / Depends on

Related to #7 

#### How does this PR make you feel? [:link:](http://giphy.com/)

When I realized I forgot of pushing the commit:
![](https://media.giphy.com/media/tZiLOffTNGoak/giphy.gif)
