### PR TITLE
Fixing youtube player not being muted when autoPlay is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Youtube player not being muted when `autoPlay` is enabled
 
 ## [1.4.1] - 2021-03-10
 ### Fixed

--- a/react/players/YoutubePlayer.tsx
+++ b/react/players/YoutubePlayer.tsx
@@ -15,6 +15,7 @@ function YoutubePlayer({
   controlsType,
   loop,
   playsInline,
+  muted,
   src,
   description,
   classes,
@@ -26,7 +27,9 @@ function YoutubePlayer({
     loop ? `1&playlist=${videoId}` : '0'
   }&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&controls=${
     controlsType === 'none' ? 0 : 1
-  }&playsinline=${playsInline ? '1' : '0'}`
+  }&playsinline=${playsInline ? '1' : '0'}&mute=${
+    autoPlay || muted ? '1' : '0'
+  }`
 
   return (
     <div className={`relative ${handles.videoContainer}`}>


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes an issue where the youtube would not autoPlay due to it not being muted (automatically or not).

Fixes https://github.com/vtex-apps/store-discussion/issues/573

#### How to test it?

[Workspace](https://icarovideo--storecomponents.myvtex.com/about-us)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/XdE6xmmh80kUyoyxAO/giphy.gif)
