### PR TITLE
fix: add support for YouTube Shorts in regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2025-05-19
+
+### Fixed
+- Added support for YouTube Shorts URLs (e.g. `https://www.youtube.com/shorts/...`) in the YoutubePlayer component by updating the video ID regex.
+
 ## [1.4.3] - 2021-12-08
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-video",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "title": "Video",
   "description": "Store component to handle video",
   "builders": {

--- a/react/package.json
+++ b/react/package.json
@@ -26,5 +26,5 @@
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
   },
-  "version": "1.4.3"
+  "version": "1.4.4"
 }

--- a/react/players/YoutubePlayer.tsx
+++ b/react/players/YoutubePlayer.tsx
@@ -5,8 +5,8 @@ import type { VideoPlayer } from '../VideoTypes'
 
 const CSS_HANDLES = ['videoContainer', 'videoElement'] as const
 
-// https://regex101.com/r/CWmgOb/1
-const YOUTUBE_REGEX = /(?:youtube(?:-nocookie)?\.com\/(?:[^/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+// https://regex101.com/r/ZoBzAb/1
+const YOUTUBE_REGEX = /(?:youtube(?:-nocookie)?\.com\/(?:[^\n\s]+\/\S+\/|(?:v|e(?:mbed)?|shorts)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
 
 function YoutubePlayer({
   width,


### PR DESCRIPTION
#### What problem is this solving?

The current regex used to extract the video ID from YouTube URLs in `YoutubePlayer.tsx` does not support YouTube Shorts URLs (e.g., `https://www.youtube.com/shorts/ZQuwy2ChKQE`). This prevents videos from this format from being rendered correctly.

#### How to test it?

Use a workspace where this branch is linked and add a video block using a Shorts URL. The video should now render as expected.

#### Screenshots or example usage:

Before (current `master`):
- Shorts URL does not render video.

After (with this PR):
- Shorts URL renders the YouTube video correctly.

#### Describe alternatives you've considered, if any.

Considered handling Shorts URLs separately, but updating the regex to include `/shorts/` is simpler and keeps logic centralized.

#### Related to / Depends on

Closes #12  

#### How does this PR make you feel? [:link:](http://giphy.com/)

![😄](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzJodzBidnNoeDdxbXI3dTh6ZG9hZ3BoY3kydDR2YnRka3Flc3oydyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zlVf2eSgXIFFuTnEhz/giphy.gif)

